### PR TITLE
Uri based host check

### DIFF
--- a/src/Fleck.Tests/ClientHandshakeTest.cs
+++ b/src/Fleck.Tests/ClientHandshakeTest.cs
@@ -1,0 +1,21 @@
+﻿namespace Fleck.Tests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ClientHandshakeTest
+    {
+        [Test]
+        public void HostnameShouldMatchOnUri()
+        {
+            var clientHandshake = new ClientHandshake();
+            clientHandshake.Key1 = "aaa";
+            clientHandshake.Key2 = "bbb";
+            clientHandshake.Origin = "AAA";
+            clientHandshake.ResourcePath = "BBB";
+
+            clientHandshake.Host = "localhost:8181";
+            Assert.IsTrue(clientHandshake.Validate(null, "ws://localhost:8181/"));
+        }
+    }
+}

--- a/src/Fleck.Tests/Fleck.Tests.csproj
+++ b/src/Fleck.Tests/Fleck.Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientHandshakeTest.cs" />
     <Compile Include="HandshakeHandlerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReceiverTests.cs" />

--- a/src/Fleck/ClientHandshake.cs
+++ b/src/Fleck/ClientHandshake.cs
@@ -53,7 +53,7 @@ namespace Fleck
 			                         (Origin != null) &&
 			                         (ResourcePath != null);
 
-			return hasRequiredFields && "ws://" + Host == host && (origin == null || origin == Origin);
+			return hasRequiredFields && new Uri("ws://" + Host) == new Uri(host) && (origin == null || origin == Origin);
 
 		}
 	}


### PR DESCRIPTION
Hi,

I ran into a minor validation issue where ws://localhost didn't match ws://localhost/ (note the trailing /)
Included is a patch to base the ClientHandshake host validation on Uri to resolve these notation differences.

Thanks for the lib and hope you can include it.

cheers,
Ernst
