### PR TITLE
MD5 & SHA1 are not thread safe

### DIFF
--- a/src/Fleck/Handlers/Draft76Handler.cs
+++ b/src/Fleck/Handlers/Draft76Handler.cs
@@ -11,8 +11,7 @@ namespace Fleck.Handlers
         private const byte End = 255;
         private const byte Start = 0;
         private const int MaxSize = 1024 * 1024 * 5;
-        private static readonly MD5 Md5 = MD5.Create();
-        
+                
         public static IHandler Create(WebSocketHttpRequest request, Action<string> onMessage)
         {
             return new ComposableHandler
@@ -97,8 +96,8 @@ namespace Fleck.Handlers
             Array.Copy(result1Bytes, 0, rawAnswer, 0, 4);
             Array.Copy(result2Bytes, 0, rawAnswer, 4, 4);
             Array.Copy(challenge.Array, challenge.Offset, rawAnswer, 8, 8);
-
-            return Md5.ComputeHash(rawAnswer);
+            
+            return MD5.Create().ComputeHash(rawAnswer);
         }
 
         private static byte[] ParseKey(string key)

--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -152,15 +152,13 @@ namespace Fleck.Handlers
             return Encoding.ASCII.GetBytes(builder.ToString());
         }
 
-        private static SHA1 Sha1 = SHA1.Create();
-        
         private const string WebSocketResponseGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         
         public static string CreateResponseKey(string requestKey)
         {
             var combined = requestKey + WebSocketResponseGuid;
 
-            var bytes = Sha1.ComputeHash(Encoding.ASCII.GetBytes(combined));
+            var bytes = SHA1.Create().ComputeHash(Encoding.ASCII.GetBytes(combined));
 
             return Convert.ToBase64String(bytes);
         }


### PR DESCRIPTION
Hi,

I ran into a problem when building a lot of connection at the same time. It turns out MD5 & Sha1 instances are not thread safe and invalid hashes where being generated. I've moved them to a local scope .

See Thread safety here:
http://msdn.microsoft.com/en-us/library/system.security.cryptography.sha1.aspx
