### PR TITLE
Fixes #28.

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -74,12 +74,10 @@ namespace Fleck
 
             connection = new WebSocketConnection(
                 clientSocket,
+                _config,
                 bytes => RequestParser.Parse(bytes, _scheme),
                 r => HandlerFactory.BuildHandler(r, s => connection.OnMessage(s),
                                                          connection.Close));
-
-            _config(connection);
-
 
             if (IsSecure)
             {


### PR DESCRIPTION
Only invoke start callback after the connection request. This way the connection info of the request is set when the callback is invoked.
