### PR TITLE
Perhaps, custom LogAction should not have to deal with filtering on level?

### DIFF
--- a/src/Fleck.Tests/Fleck.Tests.csproj
+++ b/src/Fleck.Tests/Fleck.Tests.csproj
@@ -61,6 +61,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AssemblyTests.cs" />
+    <Compile Include="FleckLogTests.cs" />
     <Compile Include="WebSocketConnectionInfoTests.cs" />
     <Compile Include="WebSocketConnectionTests.cs" />
     <Compile Include="WebSocketServerTests.cs" />

--- a/src/Fleck.Tests/FleckLogTests.cs
+++ b/src/Fleck.Tests/FleckLogTests.cs
@@ -1,0 +1,66 @@
+﻿using NUnit.Framework;
+
+namespace Fleck.Tests
+{
+    [TestFixture]
+    public class FleckLogTests
+    {
+        protected int CallCount;
+        protected const string Msg = "Test";
+
+        [SetUp]
+        public void SetUp()
+        {
+            CallCount = 0;
+            FleckLog.LogAction = (level, s, arg3) => CallCount++;
+        }
+
+        [Test]
+        public void When_level_is_Debug_Then_CallCount_is_4()
+        {
+            FleckLog.Level = LogLevel.Debug;
+            FleckLog.Debug(Msg);
+            FleckLog.Info(Msg);
+            FleckLog.Warn(Msg);
+            FleckLog.Error(Msg);
+
+            Assert.AreEqual(4, CallCount);
+        }
+
+        [Test]
+        public void When_level_is_Info_Then_CallCount_is_3()
+        {
+            FleckLog.Level = LogLevel.Info;
+            FleckLog.Debug(Msg);
+            FleckLog.Info(Msg);
+            FleckLog.Warn(Msg);
+            FleckLog.Error(Msg);
+
+            Assert.AreEqual(3, CallCount);
+        }
+
+        [Test]
+        public void When_level_is_Warn_Then_CallCount_is_2()
+        {
+            FleckLog.Level = LogLevel.Warn;
+            FleckLog.Debug(Msg);
+            FleckLog.Info(Msg);
+            FleckLog.Warn(Msg);
+            FleckLog.Error(Msg);
+
+            Assert.AreEqual(2, CallCount);
+        }
+
+        [Test]
+        public void When_level_is_Error_Then_CallCount_is_1()
+        {
+            FleckLog.Level = LogLevel.Error;
+            FleckLog.Debug(Msg);
+            FleckLog.Info(Msg);
+            FleckLog.Warn(Msg);
+            FleckLog.Error(Msg);
+
+            Assert.AreEqual(1, CallCount);
+        }
+    }
+}

--- a/src/Fleck/FleckLog.cs
+++ b/src/Fleck/FleckLog.cs
@@ -14,31 +14,36 @@ namespace Fleck
     {
         public static LogLevel Level = LogLevel.Info;
 
-        public static Action<LogLevel, string, Exception> LogAction = (level, message, ex) =>
-        {
-            if (level >= Level)
-                Console.WriteLine("{0} [{1}] {2} {3}", DateTime.Now, level, message, ex);
-        };
+        public static Action<LogLevel, string, Exception> LogAction = (level, message, ex) 
+            => Console.WriteLine("{0} [{1}] {2} {3}", DateTime.Now, level, message, ex);
 
         public static void Warn(string message, Exception ex = null)
         {
-            LogAction(LogLevel.Warn, message, ex);
+            if(ShouldLog(LogLevel.Warn))
+                LogAction(LogLevel.Warn, message, ex);
         }
 
         public static void Error(string message, Exception ex = null)
         {
-            LogAction(LogLevel.Error, message, ex);
+            if (ShouldLog(LogLevel.Error))
+                LogAction(LogLevel.Error, message, ex);
         }
 
         public static void Debug(string message, Exception ex = null)
         {
-            LogAction(LogLevel.Debug, message, ex);
+            if (ShouldLog(LogLevel.Debug))
+                LogAction(LogLevel.Debug, message, ex);
         }
 
         public static void Info(string message, Exception ex = null)
         {
-            LogAction(LogLevel.Info, message, ex);
+            if (ShouldLog(LogLevel.Info))
+                LogAction(LogLevel.Info, message, ex);
         }
 
+        protected static bool ShouldLog(LogLevel level)
+        {
+            return (level >= Level);
+        }
     }
 }


### PR DESCRIPTION
If someone sets a custom `FleckLog.LogAction`, why should they have to bother about filtering on `LogLevel`?

//Daniel
