### PR TITLE
Fix for Issue #55

### DIFF
--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -197,6 +197,7 @@ namespace Fleck
 
         private void CloseSocket()
         {
+            _closed = true;
             OnClose();
             Socket.Close();
             Socket.Dispose();


### PR DESCRIPTION
Moved closed bool to prevent multiple asyn callbacks from processing
when server has initiated a close, issue occurs when server disconnects
client, not when client disconnects from server.
