### PR TITLE
IWebSocketConnection can run a callback when a message has been sent

### DIFF
--- a/src/Fleck/Interfaces/IWebSocketConnection.cs
+++ b/src/Fleck/Interfaces/IWebSocketConnection.cs
@@ -11,10 +11,10 @@ namespace Fleck
         Action<byte[]> OnPing { get; set; }
         Action<byte[]> OnPong { get; set; }
         Action<Exception> OnError { get; set; }
-        void Send(string message);
-        void Send(byte[] message);
-        void SendPing(byte[] message);
-        void SendPong(byte[] message);
+        void Send(string message, Action onSent = null);
+        void Send(byte[] message, Action onSent = null);
+        void SendPing(byte[] message, Action onSent = null);
+        void SendPong(byte[] message, Action onSent = null);
         void Close();
         IWebSocketConnectionInfo ConnectionInfo { get; }
         bool IsAvailable { get; }

--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -14,7 +14,7 @@ namespace Fleck
       OnClose = () => { };
       OnMessage = x => { };
       OnBinary = x => { };
-      OnPing = SendPong;
+      OnPing = x => SendPong(x);
       OnPong = x => { };
       OnError = x => { };
       _initialize = initialize;
@@ -56,27 +56,27 @@ namespace Fleck
       get { return !_closing && !_closed && Socket.Connected; }
     }
 
-    public void Send(string message)
+    public void Send(string message, Action onSent = null)
     {
-      Send(message, Handler.FrameText);
+      Send(message, Handler.FrameText, onSent);
     }
 
-    public void Send(byte[] message)
+    public void Send(byte[] message, Action onSent = null)
     {
-      Send(message, Handler.FrameBinary);
+      Send(message, Handler.FrameBinary, onSent);
     }
 
-    public void SendPing(byte[] message)
+    public void SendPing(byte[] message, Action onSent = null)
     {
-      Send(message, Handler.FramePing);
+      Send(message, Handler.FramePing, onSent);
     }
 
-    public void SendPong(byte[] message)
+    public void SendPong(byte[] message, Action onSent = null)
     {
-      Send(message, Handler.FramePong);
+      Send(message, Handler.FramePong, onSent);
     }
 
-    private void Send<T>(T message, Func<T, byte[]> createFrame)
+    private void Send<T>(T message, Func<T, byte[]> createFrame, Action onSent)
     {
       if (Handler == null)
         throw new InvalidOperationException("Cannot send before handshake");
@@ -87,7 +87,7 @@ namespace Fleck
       }
 
       var bytes = createFrame(message);
-      SendBytes(bytes);
+      SendBytes(bytes, onSent);
     }
 
     public void StartReceiving()


### PR DESCRIPTION
We have a scenario where we need to send a large message in chunks and don't want to block up the socket while doing so. With this functionality we can send a chunk then wait until it has been fully transmitted before sending another, this allows other messages to be sent over the pipe in the meantime.

If you can think of a more appropriate way to implement this functionality I would be happy to implement it, but this seemed the simplest.