### PR TITLE
Restart listener socket after error.

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -63,7 +63,22 @@ namespace Fleck
 
         private void ListenForClients()
         {
-            ListenerSocket.Accept(OnClientConnect, e => FleckLog.Error("Listener socket is closed", e));
+            ListenerSocket.Accept(OnClientConnect, e => {
+                FleckLog.Error("Listener socket is closed", e);
+                FleckLog.Info("Listener socket restarting");
+                try
+                {
+                    ListenerSocket.Dispose();
+                    var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+                    ListenerSocket = new SocketWrapper(socket);
+                    Start(_config);
+                    FleckLog.Info("Listener socket restarted");
+                }
+                catch (Exception ex)
+                {
+                    FleckLog.Error("Listener could not be restarted", ex);
+                }
+            });
         }
 
         private void OnClientConnect(ISocket clientSocket)


### PR DESCRIPTION
I found that sometimes the listener socket errors, and this prevents an further clients connecting.
This patch restarts the listener after an error so that new clients can connect.