### PR TITLE
Add enum entry to allow logging to be disabled

### DIFF
--- a/src/Fleck/FleckLog.cs
+++ b/src/Fleck/FleckLog.cs
@@ -7,7 +7,8 @@ namespace Fleck
         Debug,
         Info,
         Warn,
-        Error
+        Error,
+        Disabled
     }
 
     public class FleckLog


### PR DESCRIPTION
The additional enum entry allows the user to set a level in FleckLog.Level
which results in nothing being logged (not even errors).
