### PR TITLE
Fix parsing of Cookie header without spaces

### DIFF
--- a/src/Fleck.Tests/WebSocketConnectionInfoTests.cs
+++ b/src/Fleck.Tests/WebSocketConnectionInfoTests.cs
@@ -68,6 +68,21 @@ namespace Fleck.Tests
         }
 
         [Test]
+        public void ShouldParseCookiesWithoutSpaces()
+        {
+            const string cookie = "chocolate=tasty;cabbage=not so much;";
+            var request =
+                new WebSocketHttpRequest
+                {
+                    Headers = { { "Cookie", cookie } }
+                };
+
+            var info = WebSocketConnectionInfo.Create(request, null, 1, null);
+            Assert.AreEqual(info.Cookies["chocolate"], "tasty");
+            Assert.AreEqual(info.Cookies["cabbage"], "not so much");
+        }
+
+        [Test]
         public void ShouldHaveId()
         {
             var request = new WebSocketHttpRequest();

--- a/src/Fleck/WebSocketConnectionInfo.cs
+++ b/src/Fleck/WebSocketConnectionInfo.cs
@@ -6,7 +6,7 @@ namespace Fleck
 {
     public class WebSocketConnectionInfo : IWebSocketConnectionInfo
     {
-        const string CookiePattern = @"((;\s)*(?<cookie_name>[^=]+)=(?<cookie_value>[^\;]+))+";
+        const string CookiePattern = @"((;)*(\s)*(?<cookie_name>[^=]+)=(?<cookie_value>[^\;]+))+";
         private static readonly Regex CookieRegex = new Regex(CookiePattern, RegexOptions.Compiled);
 
         public static WebSocketConnectionInfo Create(WebSocketHttpRequest request, string clientIp, int clientPort, string negotiatedSubprotocol)


### PR DESCRIPTION
Duplicate of issue #77 . 

The issue arises when the cookie string is sent in without a space between the terminating semi-colon of one key-value pair and the beginning of the next key-value pair. 

Due to the first unnamed capturing group being defined as a semi-colon followed by a white-space, a semi-colon without following white-space will not be captured, leaving it to be captured by the cookie-name group. This is why all cookies after the first one have a semi-colon as the first character of the key when there are no spaces. 

Modified the Regex to capture 0 or more semi-colons and 0 or more whitespace characters independently. 
