### PR TITLE
Fix for running on Mono

### DIFF
--- a/src/Fleck.Tests/WebSocketServerTests.cs
+++ b/src/Fleck.Tests/WebSocketServerTests.cs
@@ -84,14 +84,20 @@ namespace Fleck.Tests
             _ipV6Socket.Connect(_ipV6Address, 8000);
         }
 
-        [Test]
-        public void ShouldSupportDualStackListenWhenServerV6All()
-        {
-            _server = new WebSocketServer("ws://[::]:8000");
-            _server.Start(connection => { });
-            _ipV4Socket.Connect(_ipV4Address, 8000);
-            _ipV6Socket.Connect(_ipV6Address, 8000);
-        }
+        #if __MonoCS__
+          // None
+        #else
+
+            [Test]
+            public void ShouldSupportDualStackListenWhenServerV6All()
+            {
+                _server = new WebSocketServer("ws://[::]:8000");
+                _server.Start(connection => { });
+                _ipV4Socket.Connect(_ipV4Address, 8000);
+                _ipV6Socket.Connect(_ipV6Address, 8000);
+            }
+
+        #endif
 
         [TearDown]
         public void TearDown()

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -25,7 +25,11 @@ namespace Fleck
             _locationIP = ParseIPAddress(uri);
             _scheme = uri.Scheme;
             var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
-            socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
+            #if __MonoCS__
+              // None
+            #else
+              socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
+            #endif
             ListenerSocket = new SocketWrapper(socket);
             SupportedSubProtocols = new string[0];
         }

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="..\src\Fleck.Tests\packages.config" />
+  <repository path="../Fleck.Tests/packages.config" />
   <repository path="..\Fleck.Tests\packages.config" />
+  <repository path="..\src\Fleck.Tests\packages.config" />
 </repositories>


### PR DESCRIPTION
Fix for Fleck not working fully on Mono so added compiler runtime checks. Tested on Windows 8.1 also.