### PR TITLE
Expose the internal task of the send operations as a return value

### DIFF
--- a/src/Fleck/ConnectionNotAvailableException.cs
+++ b/src/Fleck/ConnectionNotAvailableException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Fleck
+{
+    public class ConnectionNotAvailableException : Exception
+    {
+        public ConnectionNotAvailableException() : base()
+        {
+        }
+
+        public ConnectionNotAvailableException(string message) : base(message)
+        {
+        }
+
+        public ConnectionNotAvailableException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Fleck/Fleck.csproj
+++ b/src/Fleck/Fleck.csproj
@@ -65,6 +65,7 @@
     </When>
   </Choose>
   <ItemGroup>
+    <Compile Include="ConnectionNotAvailableException.cs" />
     <Compile Include="Handlers\ComposableHandler.cs" />
     <Compile Include="Handlers\Draft76Handler.cs" />
     <Compile Include="Handlers\Hybi13Handler.cs" />

--- a/src/Fleck/Interfaces/IWebSocketConnection.cs
+++ b/src/Fleck/Interfaces/IWebSocketConnection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Fleck
 {
@@ -8,13 +9,13 @@ namespace Fleck
         Action OnClose { get; set; }
         Action<string> OnMessage { get; set; }
         Action<byte[]> OnBinary { get; set; }
-        Action<byte[]> OnPing { get; set; }
+        Func<byte[], Task> OnPing { get; set; }
         Action<byte[]> OnPong { get; set; }
         Action<Exception> OnError { get; set; }
-        void Send(string message);
-        void Send(byte[] message);
-        void SendPing(byte[] message);
-        void SendPong(byte[] message);
+        Task Send(string message);
+        Task Send(byte[] message);
+        Task SendPing(byte[] message);
+        Task SendPong(byte[] message);
         void Close();
         IWebSocketConnectionInfo ConnectionInfo { get; }
         bool IsAvailable { get; }

--- a/src/Fleck/Interfaces/IWebSocketConnection.cs
+++ b/src/Fleck/Interfaces/IWebSocketConnection.cs
@@ -9,7 +9,7 @@ namespace Fleck
         Action OnClose { get; set; }
         Action<string> OnMessage { get; set; }
         Action<byte[]> OnBinary { get; set; }
-        Func<byte[], Task> OnPing { get; set; }
+        Action<byte[]> OnPing { get; set; }
         Action<byte[]> OnPong { get; set; }
         Action<Exception> OnError { get; set; }
         Task Send(string message);

--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -82,9 +82,11 @@ namespace Fleck
       if (Handler == null)
         throw new InvalidOperationException("Cannot send before handshake");
 
-      if (!IsAvailable) {
-        FleckLog.Warn("Data sent while closing or after close. Ignoring.");
-        return null;
+      if (!IsAvailable)
+      {
+          const string errorMessage = "Data sent while closing or after close. Ignoring.";
+          FleckLog.Warn(errorMessage);
+          return Task.Factory.StartNew(() => { throw new ConnectionNotAvailableException(errorMessage); });
       }
 
       var bytes = createFrame(message);

--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -15,7 +15,7 @@ namespace Fleck
       OnClose = () => { };
       OnMessage = x => { };
       OnBinary = x => { };
-      OnPing = SendPong;
+      OnPing = x => SendPong(x);
       OnPong = x => { };
       OnError = x => { };
       _initialize = initialize;
@@ -45,7 +45,7 @@ namespace Fleck
 
     public Action<byte[]> OnBinary { get; set; }
 
-    public Func<byte[], Task> OnPing { get; set; }
+    public Action<byte[]> OnPing { get; set; }
 
     public Action<byte[]> OnPong { get; set; }
 


### PR DESCRIPTION
Exposing the Task object gives the caller to the the Send method, an access to asynchronous send operation.

An example benefit is that if the caller needs to guarantee that an order is being kept between consecutive 
send operations, he can wait for the task to complete and only then call Send again.