### PR TITLE
Retry feature added for exceptions while listening client connections

### DIFF
--- a/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
+++ b/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
@@ -8,7 +8,7 @@ namespace Fleck.Tests
         [Test]
         public void ShouldReturnHandlerForValidHeaders()
         {
-            var request = new WebSocketHttpRequest {Headers = {{"Sec-WebSocket-Key1", "BLAH"}}};
+			var request = new WebSocketHttpRequest { Headers = { { "Sec-WebSocket-Key1", "BLAH" } }, Body = "" };
             var handler = HandlerFactory.BuildHandler(request, x => { }, () => { }, x => { }, x => { }, x => { });
             
             Assert.IsNotNull(handler);
@@ -17,8 +17,8 @@ namespace Fleck.Tests
         [Test]
         public void ShouldThrowWhenUnsupportedType()
         {
-            
-            var request = new WebSocketHttpRequest {Headers = {{"Bad", "Request"}}};
+
+	        var request = new WebSocketHttpRequest {Headers = {{"Bad", "Request"}}, Body = ""};
             Assert.Throws<WebSocketException>(() => HandlerFactory.BuildHandler(request, x => {}, () => {}, x => { }, x => { }, x => { }));
             
         }

--- a/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
+++ b/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
@@ -8,7 +8,7 @@ namespace Fleck.Tests
         [Test]
         public void ShouldReturnHandlerForValidHeaders()
         {
-			var request = new WebSocketHttpRequest { Headers = { { "Sec-WebSocket-Key1", "BLAH" } }, Body = "" };
+            var request = new WebSocketHttpRequest {Headers = {{"Sec-WebSocket-Key1", "BLAH"}}};
             var handler = HandlerFactory.BuildHandler(request, x => { }, () => { }, x => { }, x => { }, x => { });
             
             Assert.IsNotNull(handler);
@@ -17,8 +17,8 @@ namespace Fleck.Tests
         [Test]
         public void ShouldThrowWhenUnsupportedType()
         {
-
-	        var request = new WebSocketHttpRequest {Headers = {{"Bad", "Request"}}, Body = ""};
+            
+            var request = new WebSocketHttpRequest {Headers = {{"Bad", "Request"}}};
             Assert.Throws<WebSocketException>(() => HandlerFactory.BuildHandler(request, x => {}, () => {}, x => { }, x => { }, x => { }));
             
         }


### PR DESCRIPTION
When there is an exception while accepting connections WebSocketServer was immediately stopping listening for new client connections. Retry feature added.

An example exception stack trace in a production environment is as follows;

Listener socket is closed Fleck Exception: Mesaj: One or more errors occurred.<rn>Stack Trace: <rn>Inner Exception Mesaj: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.<rn>Inner Exception Stack Trace:    at System.Net.Sockets.NetworkStream.BeginRead(Byte[] buffer, Int32 offset, Int32 size, AsyncCallback callback, Object state)<rn>   at System.Net.FixedSizeReader.StartReading()<rn>   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)<rn>   at System.Net.Security.SslState.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest)<rn>   at System.Net.Security.SslState.ProcessAuthentication(LazyAsyncResult lazyResult)<rn>   at System.Net.Security.SslStream.BeginAuthenticateAsServer(X509Certificate serverCertificate, Boolean clientCertificateRequired, SslProtocols enabledSslProtocols, Boolean checkCertificateRevocation, AsyncCallback asyncCallback, Object asyncState)<rn>   at Fleck.SocketWrapper.<>c__DisplayClass4.<Authenticate>b__0(AsyncCallback cb, Object s)<rn>   at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl(Func`3 beginMethod, Func`2 endFunction, Action`1 endAction, Object state, TaskCreationOptions creationOptions)<rn>   at System.Threading.Tasks.TaskFactory.FromAsync(Func`3 beginMethod, Action`1 endMethod, Object state, TaskCreationOptions creationOptions)<rn>   at System.Threading.Tasks.TaskFactory.FromAsync(Func`3 beginMethod, Action`1 endMethod, Object state)<rn>   at Fleck.SocketWrapper.Authenticate(X509Certificate2 certificate, Action callback, Action`1 error)<rn>   at Fleck.WebSocketServer.OnClientConnect(ISocket clientSocket)<rn>   at Fleck.SocketWrapper.<>c__DisplayClass14.<Accept>b__12(Task`1 t)<rn>   at System.Threading.Tasks.Task.Execute()<rn>
