### PR TITLE
Add support for 0+ whitespaces before HTTP header values

### DIFF
--- a/src/Fleck.Tests/RequestParserTests.cs
+++ b/src/Fleck.Tests/RequestParserTests.cs
@@ -120,6 +120,7 @@ namespace Fleck.Tests
                 "Sec-WebSocket-Key1: 4 @1  46546xW%0l 1 5\r\n" +
                 "Origin: http://example.com\r\n" +
                 "Cookie: \r\n" +
+                "User-Agent:\r\n" +     //no space after colon
                 "\r\n" +
                 "^n:ds[4U";
             var bytes = RequestArray(emptyCookieRequest);

--- a/src/Fleck/RequestParser.cs
+++ b/src/Fleck/RequestParser.cs
@@ -6,7 +6,7 @@ namespace Fleck
     public class RequestParser
     {
         const string pattern = @"^(?<method>[^\s]+)\s(?<path>[^\s]+)\sHTTP\/1\.1\r\n" + // request line
-                               @"((?<field_name>[^:\r\n]+):\s(?<field_value>[^\r\n]*)\r\n)+" + //headers
+                               @"((?<field_name>[^:\r\n]+):(?([^\r\n])\s)*(?<field_value>[^\r\n]*)\r\n)+" + //headers
                                @"\r\n" + //newline
                                @"(?<body>.+)?";
         const string FlashSocketPolicyRequestPattern = @"^[<]policy-file-request\s*[/][>]";


### PR DESCRIPTION
Hi, I was testing an embedded browser that sends an empty HTTP User-Agent. The handshake is decoded as "[...]\r\nUser-Agent:\r\n[...]" without whitespaces between colon and carriage return and it didn't match the regex.