### PR TITLE
Fixes for failed autobahn test suites

### DIFF
--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -68,6 +68,10 @@ namespace Fleck.Handlers
                 
                 var index = 2;
                 int payloadLength;
+
+                // control frame types may only have a maximum payload length of 125 (autobahn test case 2.5)
+                if ((int)frameType >= 0x08 && (int)frameType <= 0x0F && length > 125)
+                    throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
                 
                 if (length == 127)
                 {
@@ -127,9 +131,6 @@ namespace Fleck.Handlers
             switch (frameType)
             {
             case FrameType.Close:
-                if (data.Length == 1 || data.Length>125)
-                    throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
-                    
                 if (data.Length >= 2)
                 {
                     var closeCode = (ushort)data.Take(2).ToArray().ToLittleEndianInt();

--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -76,6 +76,10 @@ namespace Fleck.Handlers
                 // control frames must not be fragmented (autobahn test case 5.1)
                 if (isControlFrame && !isFinal)
                     throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
+
+                // a close frame MAY contain data, but if it does, it must be at least 2 bytes (autobahn test case 7.3.2)
+                if (frameType == FrameType.Close && length == 1)
+                    throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
                 
                 if (length == 127)
                 {

--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -72,6 +72,10 @@ namespace Fleck.Handlers
                 // control frame types may only have a maximum payload length of 125 (autobahn test case 2.5)
                 if ((int)frameType >= 0x08 && (int)frameType <= 0x0F && length > 125)
                     throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
+
+                // control frames must not be fragmented (autobahn test case 5.1)
+                if ((int)frameType >= 0x08 && (int)frameType <= 0x0F && !isFinal)
+                    throw new WebSocketException(WebSocketStatusCodes.ProtocolError);
                 
                 if (length == 127)
                 {

--- a/src/Fleck/ReadState.cs
+++ b/src/Fleck/ReadState.cs
@@ -8,13 +8,16 @@ namespace Fleck
         public ReadState()
         {
             Data = new List<byte>();
+            FragmentNumber = 1;
         }
         public List<byte> Data { get; private set; }
         public FrameType? FrameType { get; set; }
+        public int FragmentNumber { get; set; }
         public void Clear()
         {
             Data.Clear();
             FrameType = null;
+            FragmentNumber = 1;
         }
     }
 }


### PR DESCRIPTION
I ran fleck again the autobahn test suite for validation and it detected a few errors with protocol violations,  these are the fixes to bring fleck up to compliance.