### PR TITLE
Added dynamic/private port by specifying port 0

### DIFF
--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -15,7 +15,7 @@ namespace Fleck
         int RemotePort { get; }
         Stream Stream { get; }
         bool NoDelay { get; set; }
-        Socket Socket { get; }
+        EndPoint LocalEndPoint { get; }
 
         Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
         Task Send(byte[] buffer, Action callback, Action<Exception> error);

--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -1,9 +1,10 @@
 using System;
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using System.IO;
-using System.Security.Authentication;
 
 namespace Fleck
 {
@@ -14,6 +15,7 @@ namespace Fleck
         int RemotePort { get; }
         Stream Stream { get; }
         bool NoDelay { get; set; }
+        Socket Socket { get; }
 
         Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
         Task Send(byte[] buffer, Action callback, Action<Exception> error);

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -86,9 +86,9 @@ namespace Fleck
             set { _socket.NoDelay = value; }
         }
 
-        public Socket Socket
+        public EndPoint LocalEndPoint
         {
-            get { return _socket; }
+            get { return _socket.LocalEndPoint; }
         }
 
         public Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset)

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -86,6 +86,11 @@ namespace Fleck
             set { _socket.NoDelay = value; }
         }
 
+        public Socket Socket
+        {
+            get { return _socket; }
+        }
+
         public Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset)
         {
             try

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -75,7 +75,7 @@ namespace Fleck
             var ipLocal = new IPEndPoint(_locationIP, Port);
             ListenerSocket.Bind(ipLocal);
             ListenerSocket.Listen(100);
-            Port = ((IPEndPoint)ListenerSocket.Socket.LocalEndPoint).Port;
+            Port = ((IPEndPoint)ListenerSocket.LocalEndPoint).Port;
             FleckLog.Info(string.Format("Server started at {0} (actual port {1})", Location, Port));
             if (_scheme == "wss")
             {

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -75,7 +75,8 @@ namespace Fleck
             var ipLocal = new IPEndPoint(_locationIP, Port);
             ListenerSocket.Bind(ipLocal);
             ListenerSocket.Listen(100);
-            FleckLog.Info("Server started at " + Location);
+            Port = ((IPEndPoint)ListenerSocket.Socket.LocalEndPoint).Port;
+            FleckLog.Info(string.Format("Server started at {0} (actual port {1})", Location, Port));
             if (_scheme == "wss")
             {
                 if (Certificate == null)


### PR DESCRIPTION
When opening a socket, you should be able to specify 0 as the port to allow the OS/.NET to assign an available port number. 

See the following:
https://msdn.microsoft.com/en-us/library/system.net.sockets.socket.bind(v=vs.110).aspx
https://support.microsoft.com/en-us/kb/832017
https://support.microsoft.com/en-us/kb/174904
