### PR TITLE
Updated public async methods to end with Async suffix.

### DIFF
--- a/src/Fleck.Tests/SocketWrapperTests.cs
+++ b/src/Fleck.Tests/SocketWrapperTests.cs
@@ -29,7 +29,7 @@ namespace Fleck.Tests
         [Test]
         public void ShouldCompleteAcceptTaskOnDispose()
         {
-            Task task = _wrapper.Accept(socket => { }, exception => { });
+            Task task = _wrapper.AcceptAsync(socket => { }, exception => { });
             _wrapper.Dispose();
 
             Assert.DoesNotThrow(task.Wait);
@@ -79,7 +79,7 @@ namespace Fleck.Tests
             Exception ex = null;
             _wrapper.Dispose();
             
-            var task = _wrapper.Send(new byte[1], () => {}, e => {ex = e;});
+            var task = _wrapper.SendAsync(new byte[1], () => {}, e => {ex = e;});
             
             Assert.IsNull(task);
             Assert.IsNull(ex);
@@ -89,7 +89,7 @@ namespace Fleck.Tests
         {
             Exception ex = null;
             _wrapper.Dispose();
-            _wrapper.Receive(new byte[1], i => {}, e => {ex = e;}, 0);
+            _wrapper.ReceiveAsync(new byte[1], i => {}, e => {ex = e;}, 0);
             Assert.IsInstanceOf<ObjectDisposedException>(ex);
         }
     }

--- a/src/Fleck.Tests/WebSocketConnectionTests.cs
+++ b/src/Fleck.Tests/WebSocketConnectionTests.cs
@@ -40,8 +40,8 @@ namespace Fleck.Tests
             _connection.Handler = _handlerMock.Object;
             SetupReadLengths(0);
             _connection.StartReceiving();
-            _connection.Send("Zing");
-            _socketMock.Verify(x => x.Send(It.IsAny<byte[]>(), It.IsAny<Action>(), It.IsAny<Action<Exception>>()), Times.Never());
+            _connection.SendAsync("Zing");
+            _socketMock.Verify(x => x.SendAsync(It.IsAny<byte[]>(), It.IsAny<Action>(), It.IsAny<Action<Exception>>()), Times.Never());
         }
 
         [Test]
@@ -49,8 +49,8 @@ namespace Fleck.Tests
         {
             _connection.Handler = _handlerMock.Object;
             _socketMock.SetupGet(x => x.Connected).Returns(false);
-            _connection.Send("Zing");
-            _socketMock.Verify(x => x.Send(It.IsAny<byte[]>(), It.IsAny<Action>(), It.IsAny<Action<Exception>>()), Times.Never());
+            _connection.SendAsync("Zing");
+            _socketMock.Verify(x => x.SendAsync(It.IsAny<byte[]>(), It.IsAny<Action>(), It.IsAny<Action<Exception>>()), Times.Never());
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace Fleck.Tests
         {
             _socketMock.SetupGet(x => x.Connected).Returns(false);
             _connection.StartReceiving();
-            _socketMock.Verify(x => x.Receive(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), 0), Times.Never());
+            _socketMock.Verify(x => x.ReceiveAsync(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), 0), Times.Never());
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace Fleck.Tests
         {
             _socketMock.Setup(
                 x =>
-                x.Receive(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
+                x.ReceiveAsync(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
                 .Callback<byte[], Action<int>, Action<Exception>, int>((buffer, success, error, offset) =>
                 {
                     error(new Exception());
@@ -137,7 +137,7 @@ namespace Fleck.Tests
         {
             _socketMock.Setup(
                 x =>
-                x.Receive(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
+                x.ReceiveAsync(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
                 .Callback<byte[], Action<int>, Action<Exception>, int>((buffer, success, error, offset) =>
                 {
                     error(new ObjectDisposedException("socket"));
@@ -157,7 +157,7 @@ namespace Fleck.Tests
             var index = 0;
             _socketMock.Setup(
                 x =>
-                x.Receive(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
+                x.ReceiveAsync(It.IsAny<byte[]>(), It.IsAny<Action<int>>(), It.IsAny<Action<Exception>>(), It.IsAny<int>()))
                 .Callback<byte[], Action<int>, Action<Exception>, int>((buffer, success, error, offset) =>
                 {
                     if (args.Length > index)

--- a/src/Fleck.Tests/WebSocketServerTests.cs
+++ b/src/Fleck.Tests/WebSocketServerTests.cs
@@ -42,7 +42,7 @@ namespace Fleck.Tests
             _server.Start(connection => { });
 
             socketMock.Verify(s => s.Bind(It.Is<IPEndPoint>(i => i.Port == 8000)));
-            socketMock.Verify(s => s.Accept(It.IsAny<Action<ISocket>>(), It.IsAny<Action<Exception>>()));
+            socketMock.Verify(s => s.AcceptAsync(It.IsAny<Action<ISocket>>(), It.IsAny<Action<Exception>>()));
         }
 
         [Test]

--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -15,15 +15,24 @@ namespace Fleck
         Stream Stream { get; }
         bool NoDelay { get; set; }
 
-        Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
-        Task Send(byte[] buffer, Action callback, Action<Exception> error);
-        Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset = 0);
-        Task Authenticate(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error);
+        Task<ISocket> AcceptAsync(Action<ISocket> callback, Action<Exception> error);
+        Task SendAsync(byte[] buffer, Action callback, Action<Exception> error);
+        Task<int> ReceiveAsync(byte[] buffer, Action<int> callback, Action<Exception> error, int offset = 0);
+        Task AuthenticateAsync(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error);
 
         void Dispose();
         void Close();
 
         void Bind(EndPoint ipLocal);
         void Listen(int backlog);
+
+        [Obsolete]
+        Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
+        [Obsolete]
+        Task Send(byte[] buffer, Action callback, Action<Exception> error);
+        [Obsolete]
+        Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset = 0);
+        [Obsolete]
+        Task Authenticate(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error);
     }
 }

--- a/src/Fleck/Interfaces/IWebSocketConnection.cs
+++ b/src/Fleck/Interfaces/IWebSocketConnection.cs
@@ -12,12 +12,21 @@ namespace Fleck
         Action<byte[]> OnPing { get; set; }
         Action<byte[]> OnPong { get; set; }
         Action<Exception> OnError { get; set; }
-        Task Send(string message);
-        Task Send(byte[] message);
-        Task SendPing(byte[] message);
-        Task SendPong(byte[] message);
+        Task SendAsync(string message);
+        Task SendAsync(byte[] message);
+        Task SendPingAsync(byte[] message);
+        Task SendPongAsync(byte[] message);
         void Close();
         IWebSocketConnectionInfo ConnectionInfo { get; }
         bool IsAvailable { get; }
+
+        [Obsolete]
+        Task Send(string message);
+        [Obsolete]
+        Task Send(byte[] message);
+        [Obsolete]
+        Task SendPing(byte[] message);
+        [Obsolete]
+        Task SendPong(byte[] message);
     }
 }

--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -15,7 +15,7 @@ namespace Fleck
       OnClose = () => { };
       OnMessage = x => { };
       OnBinary = x => { };
-      OnPing = x => SendPong(x);
+      OnPing = x => SendPongAsync(x);
       OnPong = x => { };
       OnError = x => { };
       _initialize = initialize;
@@ -57,22 +57,42 @@ namespace Fleck
       get { return !_closing && !_closed && Socket.Connected; }
     }
 
-    public Task Send(string message)
+    public Task SendAsync(string message)
     {
       return Send(message, Handler.FrameText);
     }
 
-    public Task Send(byte[] message)
+    public Task SendAsync(byte[] message)
     {
         return Send(message, Handler.FrameBinary);
     }
 
-    public Task SendPing(byte[] message)
+    public Task SendPingAsync(byte[] message)
     {
         return Send(message, Handler.FramePing);
     }
 
-    public Task SendPong(byte[] message)
+    public Task SendPongAsync(byte[] message)
+    {
+        return Send(message, Handler.FramePong);
+    }
+
+    Task IWebSocketConnection.Send(string message)
+    {
+        return Send(message, Handler.FrameText);
+    }
+
+    Task IWebSocketConnection.Send(byte[] message)
+    {
+        return Send(message, Handler.FrameBinary);
+    }
+
+    Task IWebSocketConnection.SendPing(byte[] message)
+    {
+        return Send(message, Handler.FramePing);
+    }
+
+    Task IWebSocketConnection.SendPong(byte[] message)
     {
         return Send(message, Handler.FramePong);
     }
@@ -149,7 +169,7 @@ namespace Fleck
       if (!IsAvailable)
         return;
 
-      Socket.Receive(buffer, r =>
+      Socket.ReceiveAsync(buffer, r =>
       {
         if (r <= 0) {
           FleckLog.Debug("0 bytes read. Closing.");
@@ -204,7 +224,7 @@ namespace Fleck
 
     private Task SendBytes(byte[] bytes, Action callback = null)
     {
-      return Socket.Send(bytes, () =>
+      return Socket.SendAsync(bytes, () =>
       {
         FleckLog.Debug("Sent " + bytes.Length + " bytes");
         if (callback != null)

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -96,7 +96,7 @@ namespace Fleck
 
         private void ListenForClients()
         {
-            ListenerSocket.Accept(OnClientConnect, e => FleckLog.Error("Listener socket is closed", e));
+            ListenerSocket.AcceptAsync(OnClientConnect, e => FleckLog.Error("Listener socket is closed", e));
         }
 
         private void OnClientConnect(ISocket clientSocket)
@@ -124,7 +124,7 @@ namespace Fleck
             {
                 FleckLog.Debug("Authenticating Secure Connection");
                 clientSocket
-                    .Authenticate(Certificate,
+                    .AuthenticateAsync(Certificate,
                                   EnabledSslProtocols,
                                   connection.StartReceiving,
                                   e => FleckLog.Warn("Failed to Authenticate", e));

--- a/src/Samples/ConsoleApp/Server.cs
+++ b/src/Samples/ConsoleApp/Server.cs
@@ -27,7 +27,7 @@ namespace Fleck.Samples.ConsoleApp
                     socket.OnMessage = message =>
                         {
                             Console.WriteLine(message);
-                            allSockets.ToList().ForEach(s => s.Send("Echo: " + message));
+                            allSockets.ToList().ForEach(s => s.SendAsync("Echo: " + message));
                         };
                 });
 
@@ -37,7 +37,7 @@ namespace Fleck.Samples.ConsoleApp
             {
                 foreach (var socket in allSockets.ToList())
                 {
-                    socket.Send(input);
+                    socket.SendAsync(input);
                 }
                 input = Console.ReadLine();
             }


### PR DESCRIPTION
Pull [request #126](https://github.com/statianzo/Fleck/pull/126) changed several public methods to become async and return a Task instead of void. This change did not include the [recommended naming convention](https://msdn.microsoft.com/en-us/library/hh191443.aspx#BKMK_NamingConvention) of naming all async methods with the Async suffix.

In my case, this caused us to introduce a bug to a project that was using Fleck. We would ignore Task returned from IWebSocketConnection.Send, and under high load the task scheduler would get backed up.

I have updated the the public methods to include the Async suffix. However, in order to maintain backwards compatibility, I have also added obsolete methods to the interfaces without the suffix.