### PR TITLE
added RestartAfterListenError

### DIFF
--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -15,7 +15,6 @@ namespace Fleck
         int RemotePort { get; }
         Stream Stream { get; }
         bool NoDelay { get; set; }
-        bool RestartAfterListenError { get; set; }
         EndPoint LocalEndPoint { get; }
 
         Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);

--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -15,6 +15,7 @@ namespace Fleck
         int RemotePort { get; }
         Stream Stream { get; }
         bool NoDelay { get; set; }
+        bool RestartAfterListenError { get; set; }
         EndPoint LocalEndPoint { get; }
 
         Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -16,7 +16,8 @@ namespace Fleck
         private Stream _stream;
         private CancellationTokenSource _tokenSource;
         private TaskFactory _taskFactory;
-        
+        private bool _restartAfterListenError;
+
         public string RemoteIpAddress
         {
             get
@@ -51,7 +52,7 @@ namespace Fleck
             _stream = new QueuedStream(ssl);
             Func<AsyncCallback, object, IAsyncResult> begin =
                 (cb, s) => ssl.BeginAuthenticateAsServer(certificate, false, enabledSslProtocols, false, cb, s);
-                
+
             Task task = Task.Factory.FromAsync(begin, ssl.EndAuthenticateAsServer, null);
             task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)
                 .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
@@ -74,7 +75,7 @@ namespace Fleck
         {
             get { return _socket.Connected; }
         }
-        
+
         public Stream Stream
         {
             get { return _stream; }
@@ -84,6 +85,12 @@ namespace Fleck
         {
             get { return _socket.NoDelay; }
             set { _socket.NoDelay = value; }
+        }
+
+        public bool RestartAfterListenError
+        {
+            get { return _restartAfterListenError; }
+            set { _restartAfterListenError = value; }
         }
 
         public EndPoint LocalEndPoint

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -16,7 +16,6 @@ namespace Fleck
         private Stream _stream;
         private CancellationTokenSource _tokenSource;
         private TaskFactory _taskFactory;
-        private bool _restartAfterListenError;
 
         public string RemoteIpAddress
         {
@@ -85,12 +84,6 @@ namespace Fleck
         {
             get { return _socket.NoDelay; }
             set { _socket.NoDelay = value; }
-        }
-
-        public bool RestartAfterListenError
-        {
-            get { return _restartAfterListenError; }
-            set { _restartAfterListenError = value; }
         }
 
         public EndPoint LocalEndPoint

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -99,7 +99,24 @@ namespace Fleck
 
         private void ListenForClients()
         {
-            ListenerSocket.Accept(OnClientConnect, e => FleckLog.Error("Listener socket is closed", e));
+            ListenerSocket.Accept(OnClientConnect, e => {
+                FleckLog.Error("Listener socket is closed", e);
+                if(ListenerSocket.RestartAfterListenError){
+                    FleckLog.Info("Listener socket restarting");
+                    try
+                    {
+                        ListenerSocket.Dispose();
+                        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+                        ListenerSocket = new SocketWrapper(socket);
+                        Start(_config);
+                        FleckLog.Info("Listener socket restarted");
+                    }
+                    catch (Exception ex)
+                    {
+                        FleckLog.Error("Listener could not be restarted", ex);
+                    }
+                }
+            });
         }
 
         private void OnClientConnect(ISocket clientSocket)

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -43,6 +43,7 @@ namespace Fleck
         public X509Certificate2 Certificate { get; set; }
         public SslProtocols EnabledSslProtocols { get; set; }
         public IEnumerable<string> SupportedSubProtocols { get; set; }
+        public bool RestartAfterListenError {get; set; }
 
         public bool IsSecure
         {
@@ -101,7 +102,7 @@ namespace Fleck
         {
             ListenerSocket.Accept(OnClientConnect, e => {
                 FleckLog.Error("Listener socket is closed", e);
-                if(ListenerSocket.RestartAfterListenError){
+                if(RestartAfterListenError){
                     FleckLog.Info("Listener socket restarting");
                     try
                     {


### PR DESCRIPTION
use server.ListenerSocket. RestartAfterListenError to automatically
restart the listener after it closes because of an error