### PR TITLE
fix for incompatible address on restart

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -107,7 +107,7 @@ namespace Fleck
                     try
                     {
                         ListenerSocket.Dispose();
-                        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+                        var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
                         ListenerSocket = new SocketWrapper(socket);
                         Start(_config);
                         FleckLog.Info("Listener socket restarted");


### PR DESCRIPTION
Previously when a listener would restart because of an error while on
an IPv6 address it would give an error ‘An address incompatible with
the requested protocol was used’. This fixes the issue.