### PR TITLE
Fix mono always using port 80 and 443

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -107,7 +107,7 @@ namespace Fleck
                     try
                     {
                         ListenerSocket.Dispose();
-                        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+                        var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
                         ListenerSocket = new SocketWrapper(socket);
                         Start(_config);
                         FleckLog.Info("Listener socket restarted");

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -22,7 +22,7 @@ namespace Fleck
         public WebSocketServer(int port, string location)
         {
             var uri = new Uri(location);
-            Port = uri.Port > 0 ? uri.Port : port;
+            Port = port;
             Location = location;
             _locationIP = ParseIPAddress(uri);
             _scheme = uri.Scheme;


### PR DESCRIPTION
I updated mono to 5.2.0 just now and it broke Fleck. `Uri.Port` now seems to default to 80 or 443 depending on the protocol. I'm not sure what's the best way to fix this, but since I'm not using port numbers in my uri anyway, this worked for me.

Also, after one year I still don't know how github works. So it seems to have included my change from one year ago.