### PR TITLE
Remove legacy port argument from WebSocketServer

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -15,14 +15,9 @@ namespace Fleck
         private Action<IWebSocketConnection> _config;
 
         public WebSocketServer(string location)
-            : this(8181, location)
-        {
-        }
-
-        public WebSocketServer(int port, string location)
         {
             var uri = new Uri(location);
-            Port = uri.Port > 0 ? uri.Port : port;
+            Port = uri.Port;
             Location = location;
             _locationIP = ParseIPAddress(uri);
             _scheme = uri.Scheme;


### PR DESCRIPTION
This shouldn't be an issue since new projects using Fleck shouldn't be using the port argument anyway. Old projects that use the port argument and update Fleck probably also update their .NET version. And if not, including the port in the string shouldn't be too difficult to fix.