### PR TITLE
Fix V3074, V3114 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ artifacts
 src/CommonAssemblyInfo.cs
 *.dotCover
 *mm_cache.bin
+src/.vs/Fleck/v15/sqlite3/storage.ide

--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -44,7 +44,9 @@ namespace Fleck.Handlers
             }
             
             memoryStream.Write(payload, 0, payload.Length);
-            
+
+            memoryStream.Dispose();
+
             return memoryStream.ToArray();
         }
         

--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Fleck
 {
-    public interface ISocket
+    public interface ISocket : IDisposable
     {
         bool Connected { get; }
         string RemoteIpAddress { get; }


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in
open source projects. A bug, found using PVS-Studio.

Warnings:
[V3074](https://www.viva64.com/en/w/v3074/) The 'ISocket' class contains 'Dispose' method. Consider making it
implement 'IDisposable' interface. ISocket.cs 11

[V3114](https://www.viva64.com/en/w/v3114/) IDisposable object 'memoryStream' is not disposed before method
returns. Hybi13Handler.cs 29