### PR TITLE
Listener fix

### DIFF
--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -17,7 +17,7 @@ namespace Fleck
         bool NoDelay { get; set; }
         EndPoint LocalEndPoint { get; }
 
-        Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
+        Task Accept(Action<ISocket> callback, Action<Exception> error);
         Task Send(byte[] buffer, Action callback, Action<Exception> error);
         Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset = 0);
         Task Authenticate(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error);

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -132,11 +132,13 @@ namespace Fleck
 
         public Task Accept(Action<ISocket> callback, Action<Exception> error)
         {
-            Func<IAsyncResult, ISocket> end = r => _tokenSource.Token.IsCancellationRequested ? null : new SocketWrapper(_socket.EndAccept(r));
+            Func<IAsyncResult, ISocket> end = r => new SocketWrapper(_socket.EndAccept(r));
             var task = _taskFactory.FromAsync(_socket.BeginAccept, end, null);
             
+            if (_tokenSource.IsCancellationRequested) return null;
+
             task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-            
+
             return task.ContinueWith (t => callback (t.Result), TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -130,14 +130,14 @@ namespace Fleck
             }
         }
 
-        public Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error)
+        public Task Accept(Action<ISocket> callback, Action<Exception> error)
         {
             Func<IAsyncResult, ISocket> end = r => _tokenSource.Token.IsCancellationRequested ? null : new SocketWrapper(_socket.EndAccept(r));
             var task = _taskFactory.FromAsync(_socket.BeginAccept, end, null);
-            task.ContinueWith(t => callback(t.Result), TaskContinuationOptions.OnlyOnRanToCompletion)
-                .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+            
             task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-            return task;
+            
+            return task.ContinueWith (t => callback (t.Result), TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
         public void Dispose()

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -132,10 +132,8 @@ namespace Fleck
 
         public Task Accept(Action<ISocket> callback, Action<Exception> error)
         {
-            Func<IAsyncResult, ISocket> end = r => new SocketWrapper(_socket.EndAccept(r));
+            Func<IAsyncResult, ISocket> end = r => _tokenSource.Token.IsCancellationRequested ? null : new SocketWrapper (_socket.EndAccept (r));
             var task = _taskFactory.FromAsync(_socket.BeginAccept, end, null);
-            
-            if (_tokenSource.IsCancellationRequested) return null;
 
             task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
 


### PR DESCRIPTION
In short: Fixes a problem with unnecessary listener socket restarts. Possible improvement of stability and memory, since Socket.Accept is not called in a recursive manner.

A solution for the problems mentioned here: https://github.com/statianzo/Fleck/issues/225

Should replace the pull-request made here: https://github.com/statianzo/Fleck/pull/226