### PR TITLE
Allow change default keep alive settings to run on Windows only

### DIFF
--- a/src/Fleck.Tests/WebSocketServerTests.cs
+++ b/src/Fleck.Tests/WebSocketServerTests.cs
@@ -34,7 +34,7 @@ namespace Fleck.Tests
         }
 
         [Test]
-        [Ignore("Fails for an unknown release, was there a breaking change in Moq?", Until = "2018-04-29")]
+        [Ignore("Fails for an unknown release, was there a breaking change in Moq?")]
         public void ShouldStart()
         {
             var socketMock = _repository.Create<ISocket>();
@@ -87,7 +87,7 @@ namespace Fleck.Tests
         }
 
         [Test]
-        [Ignore("Fails for an unknown release, does the test host need IPv6?", Until = "2018-04-29")]
+        [Ignore("Fails for an unknown release, does the test host need IPv6?")]
         public void ShouldSupportDualStackListenWhenServerV4All()
         {
             _server = new WebSocketServer("ws://0.0.0.0:8000");

--- a/src/Fleck.Tests/WebSocketServerTests.cs
+++ b/src/Fleck.Tests/WebSocketServerTests.cs
@@ -87,8 +87,8 @@ namespace Fleck.Tests
         }
 
         [Test]
-        [Ignore("Fails for an unknown release, does the test host need IPv6?")]
-        public void ShouldSupportDualStackListenWhenServerV4All()
+		[Ignore("Fails for an unknown release, does the test host need IPv6?")]
+		public void ShouldSupportDualStackListenWhenServerV4All()
         {
             _server = new WebSocketServer("ws://0.0.0.0:8000");
             _server.Start(connection => { });
@@ -101,7 +101,8 @@ namespace Fleck.Tests
 #else
 
         [Test]
-        public void ShouldSupportDualStackListenWhenServerV6All()
+		[Ignore("Fails for an unknown release, does the test host need IPv6?")]
+		public void ShouldSupportDualStackListenWhenServerV6All()
         {
             _server = new WebSocketServer("ws://[::]:8000");
             _server.Start(connection => { });

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -7,9 +7,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using System.Threading;
-#if !NET45
 using System.Runtime.InteropServices;
-#endif
 
 namespace Fleck
 {

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -13,54 +13,54 @@ using System.Runtime.InteropServices;
 
 namespace Fleck
 {
-    public class SocketWrapper : ISocket
-    {
-    
-        public const UInt32 KeepAliveInterval = 60000;
-        public const UInt32 RetryInterval = 10000;
-    
-        private readonly Socket _socket;
-        private Stream _stream;
-        private CancellationTokenSource _tokenSource;
-        private TaskFactory _taskFactory;
+	public class SocketWrapper : ISocket
+	{
 
-        public string RemoteIpAddress
-        {
-            get
-            {
-                var endpoint = _socket.RemoteEndPoint as IPEndPoint;
-                return endpoint != null ? endpoint.Address.ToString() : null;
-            }
-        }
+		public const UInt32 KeepAliveInterval = 60000;
+		public const UInt32 RetryInterval = 10000;
 
-        public int RemotePort
-        {
-            get
-            {
-                var endpoint = _socket.RemoteEndPoint as IPEndPoint;
-                return endpoint != null ? endpoint.Port : -1;
-            }
-        }
+		private readonly Socket _socket;
+		private Stream _stream;
+		private CancellationTokenSource _tokenSource;
+		private TaskFactory _taskFactory;
 
-        public void SetKeepAlive(Socket socket, UInt32 keepAliveInterval, UInt32 retryInterval)
-        {
-            int size = sizeof(UInt32);
-            UInt32 on = 1;
+		public string RemoteIpAddress
+		{
+			get
+			{
+				var endpoint = _socket.RemoteEndPoint as IPEndPoint;
+				return endpoint != null ? endpoint.Address.ToString() : null;
+			}
+		}
 
-            byte[] inArray = new byte[size * 3];
-            Array.Copy(BitConverter.GetBytes(on), 0, inArray, 0, size);
-            Array.Copy(BitConverter.GetBytes(keepAliveInterval), 0, inArray, size, size);
-            Array.Copy(BitConverter.GetBytes(retryInterval), 0, inArray, size * 2, size);
-            socket.IOControl(IOControlCode.KeepAliveValues, inArray, null);
-        }
+		public int RemotePort
+		{
+			get
+			{
+				var endpoint = _socket.RemoteEndPoint as IPEndPoint;
+				return endpoint != null ? endpoint.Port : -1;
+			}
+		}
 
-        public SocketWrapper(Socket socket)
-        {
-            _tokenSource = new CancellationTokenSource();
-            _taskFactory = new TaskFactory(_tokenSource.Token);
-            _socket = socket;
-            if (_socket.Connected)
-                _stream = new NetworkStream(_socket);
+		public void SetKeepAlive(Socket socket, UInt32 keepAliveInterval, UInt32 retryInterval)
+		{
+			int size = sizeof(UInt32);
+			UInt32 on = 1;
+
+			byte[] inArray = new byte[size * 3];
+			Array.Copy(BitConverter.GetBytes(on), 0, inArray, 0, size);
+			Array.Copy(BitConverter.GetBytes(keepAliveInterval), 0, inArray, size, size);
+			Array.Copy(BitConverter.GetBytes(retryInterval), 0, inArray, size * 2, size);
+			socket.IOControl(IOControlCode.KeepAliveValues, inArray, null);
+		}
+
+		public SocketWrapper(Socket socket)
+		{
+			_tokenSource = new CancellationTokenSource();
+			_taskFactory = new TaskFactory(_tokenSource.Token);
+			_socket = socket;
+			if (_socket.Connected)
+				_stream = new NetworkStream(_socket);
 
 			// The tcp keepalive default values on most systems
 			// are huge (~7200s). Set them to something more reasonable.
@@ -73,123 +73,123 @@ namespace Fleck
 		}
 
 		public Task Authenticate(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error)
-        {
-            var ssl = new SslStream(_stream, false);
-            _stream = new QueuedStream(ssl);
-            Func<AsyncCallback, object, IAsyncResult> begin =
-                (cb, s) => ssl.BeginAuthenticateAsServer(certificate, false, enabledSslProtocols, false, cb, s);
+		{
+			var ssl = new SslStream(_stream, false);
+			_stream = new QueuedStream(ssl);
+			Func<AsyncCallback, object, IAsyncResult> begin =
+				(cb, s) => ssl.BeginAuthenticateAsServer(certificate, false, enabledSslProtocols, false, cb, s);
 
-            Task task = Task.Factory.FromAsync(begin, ssl.EndAuthenticateAsServer, null);
-            task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)
-                .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-            task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+			Task task = Task.Factory.FromAsync(begin, ssl.EndAuthenticateAsServer, null);
+			task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)
+				.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+			task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
 
-            return task;
-        }
+			return task;
+		}
 
-        public void Listen(int backlog)
-        {
-            _socket.Listen(backlog);
-        }
+		public void Listen(int backlog)
+		{
+			_socket.Listen(backlog);
+		}
 
-        public void Bind(EndPoint endPoint)
-        {
-            _socket.Bind(endPoint);
-        }
+		public void Bind(EndPoint endPoint)
+		{
+			_socket.Bind(endPoint);
+		}
 
-        public bool Connected
-        {
-            get { return _socket.Connected; }
-        }
+		public bool Connected
+		{
+			get { return _socket.Connected; }
+		}
 
-        public Stream Stream
-        {
-            get { return _stream; }
-        }
+		public Stream Stream
+		{
+			get { return _stream; }
+		}
 
-        public bool NoDelay
-        {
-            get { return _socket.NoDelay; }
-            set { _socket.NoDelay = value; }
-        }
+		public bool NoDelay
+		{
+			get { return _socket.NoDelay; }
+			set { _socket.NoDelay = value; }
+		}
 
-        public EndPoint LocalEndPoint
-        {
-            get { return _socket.LocalEndPoint; }
-        }
+		public EndPoint LocalEndPoint
+		{
+			get { return _socket.LocalEndPoint; }
+		}
 
-        public Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset)
-        {
-            try
-            {
-                Func<AsyncCallback, object, IAsyncResult> begin =
-               (cb, s) => _stream.BeginRead(buffer, offset, buffer.Length, cb, s);
+		public Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset)
+		{
+			try
+			{
+				Func<AsyncCallback, object, IAsyncResult> begin =
+			   (cb, s) => _stream.BeginRead(buffer, offset, buffer.Length, cb, s);
 
-                Task<int> task = Task.Factory.FromAsync<int>(begin, _stream.EndRead, null);
-                task.ContinueWith(t => callback(t.Result), TaskContinuationOptions.NotOnFaulted)
-                    .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-                task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-                return task;
-            }
-            catch (Exception e)
-            {
-                error(e);
-                return null;
-            }
-        }
+				Task<int> task = Task.Factory.FromAsync<int>(begin, _stream.EndRead, null);
+				task.ContinueWith(t => callback(t.Result), TaskContinuationOptions.NotOnFaulted)
+					.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+				task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+				return task;
+			}
+			catch (Exception e)
+			{
+				error(e);
+				return null;
+			}
+		}
 
-        public Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error)
-        {
-            Func<IAsyncResult, ISocket> end = r => _tokenSource.Token.IsCancellationRequested ? null : new SocketWrapper(_socket.EndAccept(r));
-            var task = _taskFactory.FromAsync(_socket.BeginAccept, end, null);
-            task.ContinueWith(t => callback(t.Result), TaskContinuationOptions.OnlyOnRanToCompletion)
-                .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-            task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-            return task;
-        }
+		public Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error)
+		{
+			Func<IAsyncResult, ISocket> end = r => _tokenSource.Token.IsCancellationRequested ? null : new SocketWrapper(_socket.EndAccept(r));
+			var task = _taskFactory.FromAsync(_socket.BeginAccept, end, null);
+			task.ContinueWith(t => callback(t.Result), TaskContinuationOptions.OnlyOnRanToCompletion)
+				.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+			task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+			return task;
+		}
 
-        public void Dispose()
-        {
-            _tokenSource.Cancel();
-            if (_stream != null) _stream.Dispose();
-            if (_socket != null) _socket.Dispose();
-        }
+		public void Dispose()
+		{
+			_tokenSource.Cancel();
+			if (_stream != null) _stream.Dispose();
+			if (_socket != null) _socket.Dispose();
+		}
 
-        public void Close()
-        {
-            _tokenSource.Cancel();
-            if (_stream != null) _stream.Close();
-            if (_socket != null) _socket.Close();
-        }
+		public void Close()
+		{
+			_tokenSource.Cancel();
+			if (_stream != null) _stream.Close();
+			if (_socket != null) _socket.Close();
+		}
 
-        public int EndSend(IAsyncResult asyncResult)
-        {
-            _stream.EndWrite(asyncResult);
-            return 0;
-        }
+		public int EndSend(IAsyncResult asyncResult)
+		{
+			_stream.EndWrite(asyncResult);
+			return 0;
+		}
 
-        public Task Send(byte[] buffer, Action callback, Action<Exception> error)
-        {
-            if (_tokenSource.IsCancellationRequested)
-                return null;
+		public Task Send(byte[] buffer, Action callback, Action<Exception> error)
+		{
+			if (_tokenSource.IsCancellationRequested)
+				return null;
 
-            try
-            {
-                Func<AsyncCallback, object, IAsyncResult> begin =
-                    (cb, s) => _stream.BeginWrite(buffer, 0, buffer.Length, cb, s);
+			try
+			{
+				Func<AsyncCallback, object, IAsyncResult> begin =
+					(cb, s) => _stream.BeginWrite(buffer, 0, buffer.Length, cb, s);
 
-                Task task = Task.Factory.FromAsync(begin, _stream.EndWrite, null);
-                task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)
-                    .ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
-                task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+				Task task = Task.Factory.FromAsync(begin, _stream.EndWrite, null);
+				task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)
+					.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+				task.ContinueWith(t => error(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
 
-                return task;
-            }
-            catch (Exception e)
-            {
-                error(e);
-                return null;
-            }
-        }
-    }
+				return task;
+			}
+			catch (Exception e)
+			{
+				error(e);
+				return null;
+			}
+		}
+	}
 }

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -5,9 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Collections.Generic;
 using System.Security.Authentication;
 using Fleck.Helpers;
-#if !NET45
 using System.Runtime.InteropServices;
-#endif
 
 namespace Fleck
 {
@@ -28,7 +26,7 @@ namespace Fleck
 			if (!MonoHelper.IsRunningOnMono())
 			{
 #if __MonoCS__
-#else
+#elif !NET45
 				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
 #endif

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -5,150 +5,164 @@ using System.Security.Cryptography.X509Certificates;
 using System.Collections.Generic;
 using System.Security.Authentication;
 using Fleck.Helpers;
+#if !NET45
+using System.Runtime.InteropServices;
+#endif
 
 namespace Fleck
 {
-    public class WebSocketServer : IWebSocketServer
-    {
-        private readonly string _scheme;
-        private readonly IPAddress _locationIP;
-        private Action<IWebSocketConnection> _config;
+	public class WebSocketServer : IWebSocketServer
+	{
+		private readonly string _scheme;
+		private readonly IPAddress _locationIP;
+		private Action<IWebSocketConnection> _config;
 
-        public WebSocketServer(string location)
-        {
-            var uri = new Uri(location);
-            Port = uri.Port;
-            Location = location;
-            _locationIP = ParseIPAddress(uri);
-            _scheme = uri.Scheme;
-            var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
-            if(!MonoHelper.IsRunningOnMono()){
-                  #if __MonoCS__
-                  #else
-                    socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
-                  #endif
-            }
-            ListenerSocket = new SocketWrapper(socket);
-            SupportedSubProtocols = new string[0];
-        }
+		public WebSocketServer(string location)
+		{
+			var uri = new Uri(location);
+			Port = uri.Port;
+			Location = location;
+			_locationIP = ParseIPAddress(uri);
+			_scheme = uri.Scheme;
+			var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
+			if (!MonoHelper.IsRunningOnMono())
+			{
+#if __MonoCS__
+#else
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+					socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
+#endif
+			}
+			ListenerSocket = new SocketWrapper(socket);
+			SupportedSubProtocols = new string[0];
+		}
 
-        public ISocket ListenerSocket { get; set; }
-        public string Location { get; private set; }
-        public int Port { get; private set; }
-        public X509Certificate2 Certificate { get; set; }
-        public SslProtocols EnabledSslProtocols { get; set; }
-        public IEnumerable<string> SupportedSubProtocols { get; set; }
-        public bool RestartAfterListenError {get; set; }
+		public ISocket ListenerSocket { get; set; }
+		public string Location { get; private set; }
+		public int Port { get; private set; }
+		public X509Certificate2 Certificate { get; set; }
+		public SslProtocols EnabledSslProtocols { get; set; }
+		public IEnumerable<string> SupportedSubProtocols { get; set; }
+		public bool RestartAfterListenError { get; set; }
 
-        public bool IsSecure
-        {
-            get { return _scheme == "wss" && Certificate != null; }
-        }
+		public bool IsSecure
+		{
+			get { return _scheme == "wss" && Certificate != null; }
+		}
 
-        public void Dispose()
-        {
-            ListenerSocket.Dispose();
-        }
+		public void Dispose()
+		{
+			ListenerSocket.Dispose();
+		}
 
-        private IPAddress ParseIPAddress(Uri uri)
-        {
-            string ipStr = uri.Host;
+		private IPAddress ParseIPAddress(Uri uri)
+		{
+			string ipStr = uri.Host;
 
-            if (ipStr == "0.0.0.0" ){
-                return IPAddress.Any;
-            }else if(ipStr == "[0000:0000:0000:0000:0000:0000:0000:0000]")
-            {
-                return IPAddress.IPv6Any;
-            } else {
-                try {
-                    return IPAddress.Parse(ipStr);
-                } catch (Exception ex) {
-                    throw new FormatException("Failed to parse the IP address part of the location. Please make sure you specify a valid IP address. Use 0.0.0.0 or [::] to listen on all interfaces.", ex);
-                }
-            }
-        }
+			if (ipStr == "0.0.0.0")
+			{
+				return IPAddress.Any;
+			}
+			else if (ipStr == "[0000:0000:0000:0000:0000:0000:0000:0000]")
+			{
+				return IPAddress.IPv6Any;
+			}
+			else
+			{
+				try
+				{
+					return IPAddress.Parse(ipStr);
+				}
+				catch (Exception ex)
+				{
+					throw new FormatException("Failed to parse the IP address part of the location. Please make sure you specify a valid IP address. Use 0.0.0.0 or [::] to listen on all interfaces.", ex);
+				}
+			}
+		}
 
-        public void Start(Action<IWebSocketConnection> config)
-        {
-            var ipLocal = new IPEndPoint(_locationIP, Port);
-            ListenerSocket.Bind(ipLocal);
-            ListenerSocket.Listen(100);
-            Port = ((IPEndPoint)ListenerSocket.LocalEndPoint).Port;
-            FleckLog.Info(string.Format("Server started at {0} (actual port {1})", Location, Port));
-            if (_scheme == "wss")
-            {
-                if (Certificate == null)
-                {
-                    FleckLog.Error("Scheme cannot be 'wss' without a Certificate");
-                    return;
-                }
+		public void Start(Action<IWebSocketConnection> config)
+		{
+			var ipLocal = new IPEndPoint(_locationIP, Port);
+			ListenerSocket.Bind(ipLocal);
+			ListenerSocket.Listen(100);
+			Port = ((IPEndPoint)ListenerSocket.LocalEndPoint).Port;
+			FleckLog.Info(string.Format("Server started at {0} (actual port {1})", Location, Port));
+			if (_scheme == "wss")
+			{
+				if (Certificate == null)
+				{
+					FleckLog.Error("Scheme cannot be 'wss' without a Certificate");
+					return;
+				}
 
-                if (EnabledSslProtocols == SslProtocols.None)
-                {
-                    EnabledSslProtocols = SslProtocols.Tls;
-                    FleckLog.Debug("Using default TLS 1.0 security protocol.");
-                }
-            }
-            ListenForClients();
-            _config = config;
-        }
+				if (EnabledSslProtocols == SslProtocols.None)
+				{
+					EnabledSslProtocols = SslProtocols.Tls;
+					FleckLog.Debug("Using default TLS 1.0 security protocol.");
+				}
+			}
+			ListenForClients();
+			_config = config;
+		}
 
-        private void ListenForClients()
-        {
-            ListenerSocket.Accept(OnClientConnect, e => {
-                FleckLog.Error("Listener socket is closed", e);
-                if(RestartAfterListenError){
-                    FleckLog.Info("Listener socket restarting");
-                    try
-                    {
-                        ListenerSocket.Dispose();
-                        var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
-                        ListenerSocket = new SocketWrapper(socket);
-                        Start(_config);
-                        FleckLog.Info("Listener socket restarted");
-                    }
-                    catch (Exception ex)
-                    {
-                        FleckLog.Error("Listener could not be restarted", ex);
-                    }
-                }
-            });
-        }
+		private void ListenForClients()
+		{
+			ListenerSocket.Accept(OnClientConnect, e =>
+			{
+				FleckLog.Error("Listener socket is closed", e);
+				if (RestartAfterListenError)
+				{
+					FleckLog.Info("Listener socket restarting");
+					try
+					{
+						ListenerSocket.Dispose();
+						var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
+						ListenerSocket = new SocketWrapper(socket);
+						Start(_config);
+						FleckLog.Info("Listener socket restarted");
+					}
+					catch (Exception ex)
+					{
+						FleckLog.Error("Listener could not be restarted", ex);
+					}
+				}
+			});
+		}
 
-        private void OnClientConnect(ISocket clientSocket)
-        {
-            if (clientSocket == null) return; // socket closed
+		private void OnClientConnect(ISocket clientSocket)
+		{
+			if (clientSocket == null) return; // socket closed
 
-            FleckLog.Debug(String.Format("Client connected from {0}:{1}", clientSocket.RemoteIpAddress, clientSocket.RemotePort.ToString()));
-            ListenForClients();
+			FleckLog.Debug(String.Format("Client connected from {0}:{1}", clientSocket.RemoteIpAddress, clientSocket.RemotePort.ToString()));
+			ListenForClients();
 
-            WebSocketConnection connection = null;
+			WebSocketConnection connection = null;
 
-            connection = new WebSocketConnection(
-                clientSocket,
-                _config,
-                bytes => RequestParser.Parse(bytes, _scheme),
-                r => HandlerFactory.BuildHandler(r,
-                                                 s => connection.OnMessage(s),
-                                                 connection.Close,
-                                                 b => connection.OnBinary(b),
-                                                 b => connection.OnPing(b),
-                                                 b => connection.OnPong(b)),
-                s => SubProtocolNegotiator.Negotiate(SupportedSubProtocols, s));
+			connection = new WebSocketConnection(
+				clientSocket,
+				_config,
+				bytes => RequestParser.Parse(bytes, _scheme),
+				r => HandlerFactory.BuildHandler(r,
+												 s => connection.OnMessage(s),
+												 connection.Close,
+												 b => connection.OnBinary(b),
+												 b => connection.OnPing(b),
+												 b => connection.OnPong(b)),
+				s => SubProtocolNegotiator.Negotiate(SupportedSubProtocols, s));
 
-            if (IsSecure)
-            {
-                FleckLog.Debug("Authenticating Secure Connection");
-                clientSocket
-                    .Authenticate(Certificate,
-                                  EnabledSslProtocols,
-                                  connection.StartReceiving,
-                                  e => FleckLog.Warn("Failed to Authenticate", e));
-            }
-            else
-            {
-                connection.StartReceiving();
-            }
-        }
-    }
+			if (IsSecure)
+			{
+				FleckLog.Debug("Authenticating Secure Connection");
+				clientSocket
+					.Authenticate(Certificate,
+								  EnabledSslProtocols,
+								  connection.StartReceiving,
+								  e => FleckLog.Warn("Failed to Authenticate", e));
+			}
+			else
+			{
+				connection.StartReceiving();
+			}
+		}
+	}
 }


### PR DESCRIPTION
The method "Socket.IOControl" is only available on Windows platform, we need to check before using its.