### PR TITLE
Set ReuseAddress socket option for Unix. (#243)

### DIFF
--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -32,6 +32,12 @@ namespace Fleck
                 {
                     socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
                 }
+#if !NET45
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+                }
+#endif
 #endif
             }
             ListenerSocket = new SocketWrapper(socket);


### PR DESCRIPTION
Tested as working on Ubuntu 18.04 with .NET Core 2.1.402.