### PR TITLE
Add .NET 40 support and fix some bugs

### DIFF
--- a/src/Fleck/Fleck.csproj
+++ b/src/Fleck/Fleck.csproj
@@ -9,6 +9,6 @@
     <PackageProjectUrl>https://github.com/statianzo/Fleck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/statianzo/Fleck</RepositoryUrl>
     <PackageTags>websockets server html5 events</PackageTags>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard2.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -64,7 +64,7 @@ namespace Fleck
             // are huge (~7200s). Set them to something more reasonable.
 #if NET45
             SetKeepAlive(socket, KeepAliveInterval, RetryInterval);
-#else
+#elif !NET40
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 SetKeepAlive(socket, KeepAliveInterval, RetryInterval);

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -23,6 +23,7 @@ namespace Fleck
             _locationIP = ParseIPAddress(uri);
             _scheme = uri.Scheme;
             var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
+#if !NET40
             if(!MonoHelper.IsRunningOnMono()){
 #if __MonoCS__
 #else
@@ -40,6 +41,7 @@ namespace Fleck
 #endif
 #endif
             }
+#endif
             ListenerSocket = new SocketWrapper(socket);
             SupportedSubProtocols = new string[0];
         }

--- a/src/Fleck/WebSocketServer.cs
+++ b/src/Fleck/WebSocketServer.cs
@@ -15,25 +15,28 @@ namespace Fleck
         private readonly IPAddress _locationIP;
         private Action<IWebSocketConnection> _config;
 
-        public WebSocketServer(string location)
+        public WebSocketServer(string location, bool supportDualStack = true)
         {
             var uri = new Uri(location);
+
             Port = uri.Port;
             Location = location;
+            SupportDualStack = supportDualStack;
+
             _locationIP = ParseIPAddress(uri);
             _scheme = uri.Scheme;
             var socket = new Socket(_locationIP.AddressFamily, SocketType.Stream, ProtocolType.IP);
-#if !NET40
-            if(!MonoHelper.IsRunningOnMono()){
+
+            if(!MonoHelper.IsRunningOnMono() && SupportDualStack){
 #if __MonoCS__
 #else
-#if !NET45
+#if !NET45 && !NET40
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 #endif
                 {
                     socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
                 }
-#if !NET45
+#if !NET45 && !NET40
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
@@ -41,13 +44,14 @@ namespace Fleck
 #endif
 #endif
             }
-#endif
+
             ListenerSocket = new SocketWrapper(socket);
             SupportedSubProtocols = new string[0];
         }
 
         public ISocket ListenerSocket { get; set; }
         public string Location { get; private set; }
+        public bool SupportDualStack { get; }
         public int Port { get; private set; }
         public X509Certificate2 Certificate { get; set; }
         public SslProtocols EnabledSslProtocols { get; set; }


### PR DESCRIPTION
# Goal

The goal was to add the support for the .NET 40 Framework who run on the Windows XP machines. This `Fleck` library is used in an other open source project called [WampSharp](https://github.com/Code-Sharp/WampSharp) and it support also the .NET 40 Framework.
Until now we have some bugs on our XP machines and we want to fix this so that we can run our program on this OS.

# Fix

The first step was to add the `net40` in the new csproj so that we can compile for the Windows XP machines. The second step was to disable the part of the code that was causing the problem.
Here is the error that we get when we create a `WebSocketServer` :

```
System.Net.Sockets.SocketException (0x80004005): An invalid argument was supplied 	
       at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue, Boolean silent) 	
       at System.Net.Sockets.Socket.SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, Int32 optionValue) 	
       at Fleck.WebSocketServer..ctor(Int32 port, String location) 
```

And here is the code that was generated after the precompile keywords and that cause the crash :

```
#if !NET40
if(!MonoHelper.IsRunningOnMono())
{
    socket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
}
```

The fix was to remove this part of code with a precompile instruction `#if !NET40`. The library was tested and all the the Unit Tests passed.