### PR TITLE
feat: provide exception messages for WebSocketException

### DIFF
--- a/src/Fleck/WebSocketException.cs
+++ b/src/Fleck/WebSocketException.cs
@@ -3,11 +3,10 @@ namespace Fleck
 {
     public class WebSocketException : Exception
     {
-        public WebSocketException(ushort statusCode) : base()
+        public WebSocketException(ushort statusCode) : this(statusCode, PrepareExceptionMessage(statusCode))
         {
-            StatusCode = statusCode;
         }
-        
+
         public WebSocketException(ushort statusCode, string message) : base(message)
         {
             StatusCode = statusCode;
@@ -19,5 +18,10 @@ namespace Fleck
         }
         
         public ushort StatusCode { get; private set;}
+
+        private static string PrepareExceptionMessage(ushort statusCode)
+        {
+            return $"Exception with status code {statusCode}: {WebSocketStatusCodes.ConvertStatusCodeToString(statusCode)}";
+        }
     }
 }

--- a/src/Fleck/WebSocketStatusCodes.cs
+++ b/src/Fleck/WebSocketStatusCodes.cs
@@ -24,6 +24,42 @@ namespace Fleck
             InvalidFramePayloadData, PolicyViolation, MessageTooBig,
             MandatoryExt, InternalServerError
         };
+
+        public static string ConvertStatusCodeToString(ushort statusCode)
+        {
+            switch (statusCode)
+            {
+                case 1000:
+                    return nameof(NormalClosure);
+                case 1001:
+                    return nameof(GoingAway);
+                case 1002:
+                    return nameof(ProtocolError);
+                case 1003:
+                    return nameof(UnsupportedDataType);
+                case 1005:
+                    return nameof(NoStatusReceived);
+                case 1006:
+                    return nameof(AbnormalClosure);
+                case 1007:
+                    return nameof(InvalidFramePayloadData);
+                case 1008:
+                    return nameof(PolicyViolation);
+                case 1009:
+                    return nameof(MessageTooBig);
+                case 1010:
+                    return nameof(MandatoryExt);
+                case 1011:
+                    return nameof(InternalServerError);
+                case 1015:
+                    return nameof(TLSHandshake);
+                case 3000:
+                    return nameof(ApplicationError);
+
+                default:
+                    throw new ArgumentException($"Unexpected status status code: {statusCode}", nameof(statusCode));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Try to fix #290 
Actual behaviour: exceptions do not contains any information about reason when stack trace printed.
After fix behaviour: exceptions will have message with status code and reason.