### PR TITLE
Close with code added to interface

### DIFF
--- a/src/Fleck/Interfaces/IWebSocketConnection.cs
+++ b/src/Fleck/Interfaces/IWebSocketConnection.cs
@@ -17,6 +17,7 @@ namespace Fleck
         Task SendPing(byte[] message);
         Task SendPong(byte[] message);
         void Close();
+        void Close(int code);
         IWebSocketConnectionInfo ConnectionInfo { get; }
         bool IsAvailable { get; }
     }


### PR DESCRIPTION
There is Close(int code); method in WebSocketConnection, but no such method in Interface, so I added that to interface.