### PR TITLE
Sending an ArraySegment object

### DIFF
--- a/src/Fleck/Handlers/ComposableHandler.cs
+++ b/src/Fleck/Handlers/ComposableHandler.cs
@@ -8,6 +8,7 @@ namespace Fleck.Handlers
         public Func<string, byte[]> Handshake = s => new byte[0];
         public Func<string, byte[]> TextFrame = x => new byte[0];
         public Func<byte[], byte[]> BinaryFrame = x => new byte[0];
+        public Func<ArraySegment<byte>, byte[]> BinarySegmentFrame = x => new byte[0];
         public Action<List<byte>> ReceiveData = delegate { };
         public Func<byte[], byte[]> PingFrame = i => new byte[0];
         public Func<byte[], byte[]> PongFrame = i => new byte[0];
@@ -36,7 +37,12 @@ namespace Fleck.Handlers
         {
             return BinaryFrame(bytes);
         }
-        
+
+        public byte[] FrameBinary(ArraySegment<byte> bytes)
+        {
+            return BinarySegmentFrame(bytes);
+        }
+
         public byte[] FramePing(byte[] bytes)
         {
             return PingFrame(bytes);

--- a/src/Fleck/Handlers/Hybi13Handler.cs
+++ b/src/Fleck/Handlers/Hybi13Handler.cs
@@ -73,7 +73,7 @@ namespace Fleck.Handlers
                 memoryStream.WriteByte((byte)payload.Count);
             }
 
-            memoryStream.Write(payload.Array, 0, payload.Count);
+            memoryStream.Write(payload.Array, payload.Offset, payload.Count);
 
             return memoryStream.ToArray();
         }

--- a/src/Fleck/Interfaces/IHandler.cs
+++ b/src/Fleck/Interfaces/IHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 
 namespace Fleck
 {
@@ -8,6 +9,7 @@ namespace Fleck
         void Receive(IEnumerable<byte> data);
         byte[] FrameText(string text);
         byte[] FrameBinary(byte[] bytes);
+        byte[] FrameBinary(ArraySegment<byte> bytes);
         byte[] FramePing(byte[] bytes);
         byte[] FramePong(byte[] bytes);
         byte[] FrameClose(int code);

--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -67,6 +67,11 @@ namespace Fleck
         return Send(message, Handler.FrameBinary);
     }
 
+    public Task Send(ArraySegment<byte> message)
+    {
+        return Send(message, Handler.FrameBinary);
+    }
+
     public Task SendPing(byte[] message)
     {
         return Send(message, Handler.FramePing);


### PR DESCRIPTION
If we are populating a very large buffer and want to send that via a websocket;
we need that buffer to be of "right" size. To doi that, we need to either create a new `byte[]` for each message, or truncate the large buffer to the message size. If we do the truncration thing for a `byte[]` object, what we get is an `ArraySegment<byte>` object, not a new `byte[]` object. So, it should be possible to pass an ArraySegment instead of just a byte array for binary data.