### PR TITLE
expose listen Socket property in Interface ISocket.

### DIFF
--- a/src/Fleck/Fleck.csproj
+++ b/src/Fleck/Fleck.csproj
@@ -9,6 +9,6 @@
     <PackageProjectUrl>https://github.com/statianzo/Fleck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/statianzo/Fleck</RepositoryUrl>
     <PackageTags>websockets server html5 events</PackageTags>
-    <TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Fleck/Fleck.csproj
+++ b/src/Fleck/Fleck.csproj
@@ -9,6 +9,6 @@
     <PackageProjectUrl>https://github.com/statianzo/Fleck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/statianzo/Fleck</RepositoryUrl>
     <PackageTags>websockets server html5 events</PackageTags>
-    <TargetFrameworks>net40;net45;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -14,6 +14,7 @@ namespace Fleck
         string RemoteIpAddress { get; }
         int RemotePort { get; }
         Stream Stream { get; }
+        Socket Socket { get; }
         bool NoDelay { get; set; }
         EndPoint LocalEndPoint { get; }
 

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -104,6 +104,11 @@ namespace Fleck
             get { return _stream; }
         }
 
+        public Socket Socket
+        {
+            get { return _socket; }
+        }
+
         public bool NoDelay
         {
             get { return _socket.NoDelay; }


### PR DESCRIPTION
some times, need to get the underlying listen socket for other purpose. 
as I need to prevent inherit the listen socket when creating subprocess.
```c#
[DllImport("kernel32.dll", SetLastError = true)]
static extern bool SetHandleInformation(IntPtr hObject, uint dwMask, uint dwFlags);
private const uint HANDLE_FLAG_INHERIT = 1;
// ...
private static void MakeNotInheritable(Socket tcpListenedSocket)
{
    var handle = tcpListenedSocket.Handle;
    SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0);
}
```