### PR TITLE
Add the ability to limit message payload size for Hybi13Handler

### DIFF
--- a/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
+++ b/src/Fleck.Tests/DefaultHandlerFactoryTests.cs
@@ -9,7 +9,7 @@ namespace Fleck.Tests
         public void ShouldReturnHandlerForValidHeaders()
         {
             var request = new WebSocketHttpRequest {Headers = {{"Sec-WebSocket-Key1", "BLAH"}}};
-            var handler = HandlerFactory.BuildHandler(request, x => { }, () => { }, x => { }, x => { }, x => { });
+            var handler = HandlerFactory.BuildHandler(request, HandlerSettings.Default, x => { }, () => { }, x => { }, x => { }, x => { });
             
             Assert.IsNotNull(handler);
         }
@@ -19,7 +19,7 @@ namespace Fleck.Tests
         {
             
             var request = new WebSocketHttpRequest {Headers = {{"Bad", "Request"}}};
-            Assert.Throws<WebSocketException>(() => HandlerFactory.BuildHandler(request, x => {}, () => {}, x => { }, x => { }, x => { }));
+            Assert.Throws<WebSocketException>(() => HandlerFactory.BuildHandler(request, HandlerSettings.Default, x => {}, () => {}, x => { }, x => { }, x => { }));
             
         }
     }

--- a/src/Fleck.Tests/Hybi13HandlerTests.cs
+++ b/src/Fleck.Tests/Hybi13HandlerTests.cs
@@ -27,7 +27,7 @@ namespace Fleck.Tests
             _onPing = delegate { };
             _onPong = delegate { };
 
-            _handler = Hybi13Handler.Create(_request, s => _onMessage(s), () => _onClose(), b => _onBinary(b), b => _onPing(b), b => _onPong(b));
+            _handler = Hybi13Handler.Create(_request, HandlerSettings.Default, s => _onMessage(s), () => _onClose(), b => _onBinary(b), b => _onPing(b), b => _onPong(b));
         }
 
         [Test]

--- a/src/Fleck.Tests/LimitedHybi13HandlerTests.cs
+++ b/src/Fleck.Tests/LimitedHybi13HandlerTests.cs
@@ -59,24 +59,5 @@ namespace Fleck.Tests
             
             Assert.Catch<WebSocketException>(() => _handler.Receive(frame.ToBytes()));
         }
-        
-        private const string ExampleRequest =
-"GET /chat HTTP/1.1\r\n" +
-"Host: server.example.com\r\n" +
-"Upgrade: websocket\r\n" +
-"Connection: Upgrade\r\n" +
-"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
-"Origin: http://example.com\r\n" +
-"Sec-WebSocket-Protocol: chat, superchat\r\n" +
-"Sec-WebSocket-Version: 13\r\n" +
-"\r\n";
-
-        private const string ExampleResponse =
-"HTTP/1.1 101 Switching Protocols\r\n" +
-"Upgrade: websocket\r\n" +
-"Connection: Upgrade\r\n" +
-"Sec-WebSocket-Protocol: superchat\r\n" +
-"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n" +
-"\r\n";
     }
 }

--- a/src/Fleck.Tests/LimitedHybi13HandlerTests.cs
+++ b/src/Fleck.Tests/LimitedHybi13HandlerTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Text;
+using Fleck.Handlers;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Fleck.Tests
+{
+    [TestFixture]
+    public class LimitedHybi13HandlerTests
+    {
+        private IHandler _handler;
+        private WebSocketHttpRequest _request;
+        private Action<string> _onMessage;
+        private Action<byte[]> _onBinary;
+        private Action<byte[]> _onPing;
+        private Action<byte[]> _onPong;
+        private Action _onClose;
+
+        [SetUp]
+        public void Setup()
+        {
+            _request = new WebSocketHttpRequest();
+            _onClose = delegate { };
+            _onMessage = delegate { };
+            _onBinary = delegate { };
+            _onPing = delegate { };
+            _onPong = delegate { };
+
+            _handler = Hybi13Handler.Create(_request, new HandlerSettings {Hybi13MaxMessageSize = 256}, s => _onMessage(s), () => _onClose(), b => _onBinary(b), b => _onPing(b), b => _onPong(b));
+        }
+
+        [Test]
+        public void ShouldThrowWhenBinaryMessageLongerThanLimit()
+        {
+            var frame = new Hybi14DataFrame
+            {
+                FrameType = FrameType.Binary,
+                IsFinal = true,
+                IsMasked = true,
+                MaskKey = 234234,
+                Payload = new byte[257]
+            };
+            
+            Assert.Catch<WebSocketException>(() => _handler.Receive(frame.ToBytes()));
+        }
+        
+        [Test]
+        public void ShouldThrowWhenTextMessageLongerThanLimit()
+        {
+            var frame = new Hybi14DataFrame
+            {
+                FrameType = FrameType.Text,
+                IsFinal = true,
+                IsMasked = true,
+                MaskKey = 234234,
+                Payload = Encoding.UTF8.GetBytes(new string('+', 257))
+            };
+            
+            Assert.Catch<WebSocketException>(() => _handler.Receive(frame.ToBytes()));
+        }
+        
+        private const string ExampleRequest =
+"GET /chat HTTP/1.1\r\n" +
+"Host: server.example.com\r\n" +
+"Upgrade: websocket\r\n" +
+"Connection: Upgrade\r\n" +
+"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+"Origin: http://example.com\r\n" +
+"Sec-WebSocket-Protocol: chat, superchat\r\n" +
+"Sec-WebSocket-Version: 13\r\n" +
+"\r\n";
+
+        private const string ExampleResponse =
+"HTTP/1.1 101 Switching Protocols\r\n" +
+"Upgrade: websocket\r\n" +
+"Connection: Upgrade\r\n" +
+"Sec-WebSocket-Protocol: superchat\r\n" +
+"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n" +
+"\r\n";
+    }
+}

--- a/src/Fleck/HandlerFactory.cs
+++ b/src/Fleck/HandlerFactory.cs
@@ -5,7 +5,7 @@ namespace Fleck
 {
     public class HandlerFactory
     {
-        public static IHandler BuildHandler(WebSocketHttpRequest request, Action<string> onMessage, Action onClose, Action<byte[]> onBinary, Action<byte[]> onPing, Action<byte[]> onPong)
+        public static IHandler BuildHandler(WebSocketHttpRequest request, HandlerSettings settings, Action<string> onMessage, Action onClose, Action<byte[]> onBinary, Action<byte[]> onPing, Action<byte[]> onPong)
         {
             var version = GetVersion(request);
             
@@ -16,7 +16,7 @@ namespace Fleck
                 case "7":
                 case "8":
                 case "13":
-                    return Hybi13Handler.Create(request, onMessage, onClose, onBinary, onPing, onPong);
+                    return Hybi13Handler.Create(request, settings, onMessage, onClose, onBinary, onPing, onPong);
                 case "policy-file-request":
                     return FlashSocketPolicyRequestHandler.Create(request);
             }

--- a/src/Fleck/HandlerSettings.cs
+++ b/src/Fleck/HandlerSettings.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Fleck
+{
+    public class HandlerSettings
+    {
+        public static readonly HandlerSettings Default = new HandlerSettings();
+        
+        public int Hybi13MaxMessageSize { get; set; } = Int32.MaxValue;
+    }
+}


### PR DESCRIPTION
Currently, there is no way to set a custom limit for the size of incoming message. This may be something attackers can abuse to provoke a Denial of Service. 

The commits add the possibility to set this limit through a `HandlerSettings` class. An exception is thrown in `ReceiveData` method if `payloadLength` is greather than the specified limit.

(For now, I only implemented the limit check for the Hybi13Handler. Tell me in case you think this needs to be applied to the other handlers too).