### PR TITLE
Send bytes with offset and length

### DIFF
--- a/src/Fleck/Interfaces/ISocket.cs
+++ b/src/Fleck/Interfaces/ISocket.cs
@@ -19,6 +19,7 @@ namespace Fleck
 
         Task<ISocket> Accept(Action<ISocket> callback, Action<Exception> error);
         Task Send(byte[] buffer, Action callback, Action<Exception> error);
+        Task Send(byte[] buffer, int offset, int length, Action callback, Action<Exception> error);
         Task<int> Receive(byte[] buffer, Action<int> callback, Action<Exception> error, int offset = 0);
         Task Authenticate(X509Certificate2 certificate, SslProtocols enabledSslProtocols, Action callback, Action<Exception> error);
 

--- a/src/Fleck/SocketWrapper.cs
+++ b/src/Fleck/SocketWrapper.cs
@@ -14,10 +14,10 @@ namespace Fleck
 {
     public class SocketWrapper : ISocket
     {
-    
+
         public const UInt32 KeepAliveInterval = 60000;
         public const UInt32 RetryInterval = 10000;
-    
+
         private readonly Socket _socket;
         private Stream _stream;
         private CancellationTokenSource _tokenSource;
@@ -167,13 +167,17 @@ namespace Fleck
 
         public Task Send(byte[] buffer, Action callback, Action<Exception> error)
         {
+            return Send(buffer, 0, buffer.Length, callback, error);
+        }
+        public Task Send(byte[] buffer, int offset, int length, Action callback, Action<Exception> error)
+        {
             if (_tokenSource.IsCancellationRequested)
                 return null;
 
             try
             {
                 Func<AsyncCallback, object, IAsyncResult> begin =
-                    (cb, s) => _stream.BeginWrite(buffer, 0, buffer.Length, cb, s);
+                    (cb, s) => _stream.BeginWrite(buffer, offset, length, cb, s);
 
                 Task task = Task.Factory.FromAsync(begin, _stream.EndWrite, null);
                 task.ContinueWith(t => callback(), TaskContinuationOptions.NotOnFaulted)


### PR DESCRIPTION
When sending a byte array, can specify the offset and length, without creating a new object every time. This can prevent generating many memory fragments.