### PR TITLE
Add null checks to CloseSocket method

### DIFF
--- a/src/Fleck/WebSocketConnection.cs
+++ b/src/Fleck/WebSocketConnection.cs
@@ -223,8 +223,8 @@ namespace Fleck
       _closing = true;
       OnClose();
       _closed = true;
-      Socket.Close();
-      Socket.Dispose();
+      Socket?.Close();
+      Socket?.Dispose();
       _closing = false;
     }
 


### PR DESCRIPTION
Added null checks to the CloseSocket method to prevent potential NullReferenceExceptions when closing and disposing the socket.

Fixes #341